### PR TITLE
Transformer

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,10 +96,10 @@ func init() {
 	rootCmd.PersistentFlags().String("logfile", "", "file path for logging")
 
 	rootCmd.PersistentFlags().String("eth-node-id", "", "eth node id")
-	rootCmd.PersistentFlags().String("eth-client-name", "", "eth client name")
-	rootCmd.PersistentFlags().String("eth-genesis-block", "", "eth genesis block hash")
-	rootCmd.PersistentFlags().String("eth-network-id", "", "eth network id")
-	rootCmd.PersistentFlags().String("eth-chain-id", "", "eth chain id")
+	rootCmd.PersistentFlags().String("eth-client-name", "Geth", "eth client name")
+	rootCmd.PersistentFlags().String("eth-genesis-block", "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3", "eth genesis block hash")
+	rootCmd.PersistentFlags().String("eth-network-id", "1", "eth network id")
+	rootCmd.PersistentFlags().String("eth-chain-id", "1", "eth chain id")
 
 	// and their .toml config bindings
 	viper.BindPFlag("database.name", rootCmd.PersistentFlags().Lookup("database-name"))

--- a/db/migrations/00002_create_nodes_table.sql
+++ b/db/migrations/00002_create_nodes_table.sql
@@ -5,8 +5,7 @@ CREATE TABLE nodes (
   genesis_block VARCHAR(66),
   network_id    VARCHAR,
   node_id       VARCHAR(128),
-  chain_id      INTEGER,
-  CONSTRAINT node_uc UNIQUE (genesis_block, network_id, node_id, chain_id)
+  CONSTRAINT node_uc UNIQUE (genesis_block, network_id, node_id)
 );
 
 -- +goose Down

--- a/db/migrations/00002_create_nodes_table.sql
+++ b/db/migrations/00002_create_nodes_table.sql
@@ -5,7 +5,8 @@ CREATE TABLE nodes (
   genesis_block VARCHAR(66),
   network_id    VARCHAR,
   node_id       VARCHAR(128),
-  CONSTRAINT node_uc UNIQUE (genesis_block, network_id, node_id)
+  chain_id      INTEGER,
+  CONSTRAINT node_uc UNIQUE (genesis_block, network_id, node_id, chain_id)
 );
 
 -- +goose Down

--- a/db/migrations/00012_add_chain_id_to_nodes.sql
+++ b/db/migrations/00012_add_chain_id_to_nodes.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+ALTER TABLE public.nodes
+ADD COLUMN chain_id INTEGER DEFAULT 1;
+
+ALTER TABLE public.nodes
+DROP CONSTRAINT node_uc;
+
+ALTER TABLE public.nodes
+ADD CONSTRAINT node_uc
+UNIQUE (genesis_block, network_id, node_id, chain_id);
+
+-- +goose Down
+ALTER TABLE public.nodes
+DROP CONSTRAINT node_uc;
+
+ALTER TABLE public.nodes
+ADD CONSTRAINT node_uc
+UNIQUE (genesis_block, network_id, node_id);
+
+ALTER TABLE public.nodes
+DROP COLUMN chain_id;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -361,7 +361,8 @@ CREATE TABLE public.nodes (
     client_name character varying,
     genesis_block character varying(66),
     network_id character varying,
-    node_id character varying(128)
+    node_id character varying(128),
+    chain_id integer
 );
 
 
@@ -595,7 +596,7 @@ ALTER TABLE ONLY public.goose_db_version
 --
 
 ALTER TABLE ONLY public.nodes
-    ADD CONSTRAINT node_uc UNIQUE (genesis_block, network_id, node_id);
+    ADD CONSTRAINT node_uc UNIQUE (genesis_block, network_id, node_id, chain_id);
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -362,7 +362,7 @@ CREATE TABLE public.nodes (
     genesis_block character varying(66),
     network_id character varying,
     node_id character varying(128),
-    chain_id integer
+    chain_id integer DEFAULT 1
 );
 
 

--- a/pkg/eth/indexer.go
+++ b/pkg/eth/indexer.go
@@ -133,10 +133,10 @@ func (in *CIDIndexer) indexTransactionCID(tx *sqlx.Tx, transaction TxModel, head
 	return txID, err
 }
 
-func (in *CIDIndexer) indexReceiptCID(tx *sqlx.Tx, cidMeta ReceiptModel, txID int64) error {
+func (in *CIDIndexer) indexReceiptCID(tx *sqlx.Tx, rct ReceiptModel, txID int64) error {
 	_, err := tx.Exec(`INSERT INTO eth.receipt_cids (tx_id, cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 							  ON CONFLICT (tx_id) DO UPDATE SET (cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key) = ($2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-		txID, cidMeta.CID, cidMeta.Contract, cidMeta.ContractHash, cidMeta.Topic0s, cidMeta.Topic1s, cidMeta.Topic2s, cidMeta.Topic3s, cidMeta.LogContracts, cidMeta.MhKey)
+		txID, rct.CID, rct.Contract, rct.ContractHash, rct.Topic0s, rct.Topic1s, rct.Topic2s, rct.Topic3s, rct.LogContracts, rct.MhKey)
 	return err
 }
 

--- a/pkg/eth/mocks/test_data.go
+++ b/pkg/eth/mocks/test_data.go
@@ -37,7 +37,6 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/vulcanize/ipld-eth-indexer/pkg/eth"
-	"github.com/vulcanize/ipld-eth-indexer/pkg/ipfs"
 	"github.com/vulcanize/ipld-eth-indexer/pkg/ipfs/ipld"
 )
 
@@ -426,40 +425,6 @@ var (
 		},
 	}
 
-	MockCIDWrapper = &eth.CIDWrapper{
-		BlockNumber: new(big.Int).Set(BlockNumber),
-		Header: eth.HeaderModel{
-			BlockNumber:     "1",
-			BlockHash:       MockBlock.Hash().String(),
-			ParentHash:      "0x0000000000000000000000000000000000000000000000000000000000000000",
-			CID:             HeaderCID.String(),
-			MhKey:           HeaderMhKey,
-			TotalDifficulty: MockBlock.Difficulty().String(),
-			Reward:          "5000000000000000000",
-			StateRoot:       MockBlock.Root().String(),
-			RctRoot:         MockBlock.ReceiptHash().String(),
-			TxRoot:          MockBlock.TxHash().String(),
-			UncleRoot:       MockBlock.UncleHash().String(),
-			Bloom:           MockBlock.Bloom().Bytes(),
-			Timestamp:       MockBlock.Time(),
-			TimesValidated:  1,
-		},
-		Transactions: MockTrxMetaPostPublsh,
-		Receipts:     MockRctMetaPostPublish,
-		Uncles:       []eth.UncleModel{},
-		StateNodes:   MockStateMetaPostPublish,
-		StorageNodes: []eth.StorageNodeWithStateKeyModel{
-			{
-				Path:       []byte{},
-				CID:        StorageCID.String(),
-				MhKey:      StorageMhKey,
-				NodeType:   2,
-				StateKey:   common.BytesToHash(ContractLeafKey).Hex(),
-				StorageKey: common.BytesToHash(StorageLeafKey).Hex(),
-			},
-		},
-	}
-
 	HeaderIPLD, _  = blocks.NewBlockWithCid(MockHeaderRlp, HeaderCID)
 	Trx1IPLD, _    = blocks.NewBlockWithCid(MockTransactions.GetRlp(0), Trx1CID)
 	Trx2IPLD, _    = blocks.NewBlockWithCid(MockTransactions.GetRlp(1), Trx2CID)
@@ -470,74 +435,6 @@ var (
 	State1IPLD, _  = blocks.NewBlockWithCid(ContractLeafNode, State1CID)
 	State2IPLD, _  = blocks.NewBlockWithCid(AccountLeafNode, State2CID)
 	StorageIPLD, _ = blocks.NewBlockWithCid(StorageLeafNode, StorageCID)
-
-	MockIPLDs = eth.IPLDs{
-		BlockNumber: new(big.Int).Set(BlockNumber),
-		Header: ipfs.BlockModel{
-			Data: HeaderIPLD.RawData(),
-			CID:  HeaderIPLD.Cid().String(),
-		},
-		Transactions: []ipfs.BlockModel{
-			{
-				Data: Trx1IPLD.RawData(),
-				CID:  Trx1IPLD.Cid().String(),
-			},
-			{
-				Data: Trx2IPLD.RawData(),
-				CID:  Trx2IPLD.Cid().String(),
-			},
-			{
-				Data: Trx3IPLD.RawData(),
-				CID:  Trx3IPLD.Cid().String(),
-			},
-		},
-		Receipts: []ipfs.BlockModel{
-			{
-				Data: Rct1IPLD.RawData(),
-				CID:  Rct1IPLD.Cid().String(),
-			},
-			{
-				Data: Rct2IPLD.RawData(),
-				CID:  Rct2IPLD.Cid().String(),
-			},
-			{
-				Data: Rct3IPLD.RawData(),
-				CID:  Rct3IPLD.Cid().String(),
-			},
-		},
-		StateNodes: []eth.StateNode{
-			{
-				StateLeafKey: common.BytesToHash(ContractLeafKey),
-				Type:         statediff.Leaf,
-				IPLD: ipfs.BlockModel{
-					Data: State1IPLD.RawData(),
-					CID:  State1IPLD.Cid().String(),
-				},
-				Path: []byte{'\x06'},
-			},
-			{
-				StateLeafKey: common.BytesToHash(AccountLeafKey),
-				Type:         statediff.Leaf,
-				IPLD: ipfs.BlockModel{
-					Data: State2IPLD.RawData(),
-					CID:  State2IPLD.Cid().String(),
-				},
-				Path: []byte{'\x0c'},
-			},
-		},
-		StorageNodes: []eth.StorageNode{
-			{
-				StateLeafKey:   common.BytesToHash(ContractLeafKey),
-				StorageLeafKey: common.BytesToHash(StorageLeafKey),
-				Type:           statediff.Leaf,
-				IPLD: ipfs.BlockModel{
-					Data: StorageIPLD.RawData(),
-					CID:  StorageIPLD.Cid().String(),
-				},
-				Path: []byte{},
-			},
-		},
-	}
 )
 
 // createTransactionsAndReceipts is a helper function to generate signed mock transactions and mock receipts with mock logs

--- a/pkg/eth/mocks/transformer.go
+++ b/pkg/eth/mocks/transformer.go
@@ -1,0 +1,54 @@
+// VulcanizeDB
+// Copyright © 2019 Vulcanize
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mocks
+
+import (
+	"github.com/ethereum/go-ethereum/statediff"
+)
+
+// Transformer for testing
+type Transformer struct {
+	PassedWorkerID  int
+	PassedStateDiff statediff.Payload
+	ReturnHeight    int64
+	ReturnErr       error
+}
+
+// Transform mock method
+func (t *Transformer) Transform(workerID int, payload statediff.Payload) (int64, error) {
+	t.PassedWorkerID = workerID
+	t.PassedStateDiff = payload
+	return t.ReturnHeight, t.ReturnErr
+}
+
+// IterativeTransformer for testing
+type IterativeTransformer struct {
+	PassedWorkerIDs  []int
+	PassedStateDiffs []statediff.Payload
+	ReturnHeights    []int64
+	ReturnErr        error
+	iteration        int
+}
+
+// Transform mock method
+func (t *IterativeTransformer) Transform(workerID int, payload statediff.Payload) (int64, error) {
+	t.PassedWorkerIDs = append(t.PassedWorkerIDs, workerID)
+	t.PassedStateDiffs = append(t.PassedStateDiffs, payload)
+	height := t.ReturnHeights[t.iteration]
+	t.iteration++
+	return height, t.ReturnErr
+}

--- a/pkg/eth/transformer.go
+++ b/pkg/eth/transformer.go
@@ -1,0 +1,357 @@
+// VulcanizeDB
+// Copyright © 2019 Vulcanize
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/state"
+	node "github.com/ipfs/go-ipld-format"
+	"github.com/jmoiron/sqlx"
+	"github.com/multiformats/go-multihash"
+	"github.com/vulcanize/ipld-eth-indexer/pkg/ipfs/ipld"
+	"github.com/vulcanize/ipld-eth-indexer/pkg/postgres"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/statediff"
+
+	"github.com/vulcanize/ipld-eth-indexer/pkg/shared"
+)
+
+// Transformer interface to allow substitution of mocks for testing
+type Transformer interface {
+	Transform(workerID int, payload statediff.Payload) (int64, error)
+}
+
+// StateDiffTransformer satisfies the Transformer interface for ethereum statediff objects
+type StateDiffTransformer struct {
+	chainConfig *params.ChainConfig
+	indexer     *CIDIndexer
+}
+
+// NewStateDiffTransformer creates a pointer to a new PayloadConverter which satisfies the PayloadConverter interface
+func NewStateDiffTransformer(chainConfig *params.ChainConfig, db *postgres.DB) *StateDiffTransformer {
+	return &StateDiffTransformer{
+		chainConfig: chainConfig,
+		indexer:     NewCIDIndexer(db),
+	}
+}
+
+// Transform method is used to process statediff.Payload objects
+// It performs the necessary data conversions and database persistence
+func (sdt *StateDiffTransformer) Transform(workerID int, payload statediff.Payload) (int64, error) {
+	// Unpack block rlp to access fields
+	block := new(types.Block)
+	if err := rlp.DecodeBytes(payload.BlockRlp, block); err != nil {
+		return 0, err
+	}
+	blockHash := block.Hash()
+	logrus.Infof("worker %d transforming state diff payload for blocknumber %d with hash %s", workerID, block.Number().Int64(), blockHash)
+	transactions := block.Transactions()
+	// Block processing
+	// Decode receipts for this block
+	receipts := make(types.Receipts, 0)
+	if err := rlp.DecodeBytes(payload.ReceiptsRlp, &receipts); err != nil {
+		return 0, err
+	}
+	// Derive any missing fields
+	if err := receipts.DeriveFields(sdt.chainConfig, blockHash, block.NumberU64(), transactions); err != nil {
+		return 0, err
+	}
+	// Generate the block iplds
+	headerNode, uncleNodes, txNodes, txTrieNodes, rctNodes, rctTrieNodes, err := ipld.FromBlockAndReceipts(block, receipts)
+	if err != nil {
+		return 0, err
+	}
+	if len(txNodes) != len(txTrieNodes) && len(rctNodes) != len(rctTrieNodes) && len(txNodes) != len(rctNodes) {
+		return 0, fmt.Errorf("expected number of transactions (%d), transaction trie nodes (%d), receipts (%d), and receipt trie nodes (%d)to be equal", len(txNodes), len(txTrieNodes), len(rctNodes), len(rctTrieNodes))
+	}
+	// Begin new db tx for everything
+	tx, err := sdt.indexer.db.Beginx()
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			shared.Rollback(tx)
+			panic(p)
+		} else if err != nil {
+			shared.Rollback(tx)
+		} else {
+			err = tx.Commit()
+		}
+	}()
+
+	// Publish and index header, collect headerID
+	reward := CalcEthBlockReward(block.Header(), block.Uncles(), block.Transactions(), receipts)
+	headerID, err := sdt.processHeader(tx, block.Header(), headerNode, reward, payload.TotalDifficulty)
+	if err != nil {
+		return 0, err
+	}
+	// Publish and index uncles
+	if err := sdt.processUncles(tx, headerID, block.Number().Int64(), uncleNodes); err != nil {
+		return 0, err
+	}
+	// Publish and index receipts and txs
+	if err := sdt.processReceiptsAndTxs(tx, processArgs{
+		headerID:     headerID,
+		blockNumber:  block.Number(),
+		receipts:     receipts,
+		txs:          transactions,
+		rctNodes:     rctNodes,
+		rctTrieNodes: rctTrieNodes,
+		txNodes:      txNodes,
+		txTrieNodes:  txTrieNodes,
+	}); err != nil {
+		return 0, err
+	}
+
+	// Unpack state diff rlp to access fields
+	stateDiff := new(statediff.StateObject)
+	if err := rlp.DecodeBytes(payload.StateObjectRlp, stateDiff); err != nil {
+		return 0, err
+	}
+	// Publish and index state and storage nodes
+	if err := sdt.processStateAndStorage(tx, headerID, stateDiff); err != nil {
+		return 0, err
+	}
+
+	return block.Number().Int64(), err // return error explicity so that the defer() assigns to it
+}
+
+// processHeader publishes and indexes a header IPLD in Postgres
+// it returns the headerID
+func (sdt *StateDiffTransformer) processHeader(tx *sqlx.Tx, header *types.Header, headerNode node.Node, reward, td *big.Int) (int64, error) {
+	// publish header
+	if err := shared.PublishIPLD(tx, headerNode); err != nil {
+		return 0, err
+	}
+	// index header
+	return sdt.indexer.indexHeaderCID(tx, HeaderModel{
+		CID:             headerNode.Cid().String(),
+		MhKey:           shared.MultihashKeyFromCID(headerNode.Cid()),
+		ParentHash:      header.ParentHash.String(),
+		BlockNumber:     header.Number.String(),
+		BlockHash:       header.Hash().String(),
+		TotalDifficulty: td.String(),
+		Reward:          reward.String(),
+		Bloom:           header.Bloom.Bytes(),
+		StateRoot:       header.Root.String(),
+		RctRoot:         header.ReceiptHash.String(),
+		TxRoot:          header.TxHash.String(),
+		UncleRoot:       header.UncleHash.String(),
+		Timestamp:       header.Time,
+	})
+}
+
+func (sdt *StateDiffTransformer) processUncles(tx *sqlx.Tx, headerID, blockNumber int64, uncleNodes []*ipld.EthHeader) error {
+	// publish and index uncles
+	for _, uncleNode := range uncleNodes {
+		if err := shared.PublishIPLD(tx, uncleNode); err != nil {
+			return err
+		}
+		uncleReward := CalcUncleMinerReward(blockNumber, uncleNode.Number.Int64())
+		uncle := UncleModel{
+			CID:        uncleNode.Cid().String(),
+			MhKey:      shared.MultihashKeyFromCID(uncleNode.Cid()),
+			ParentHash: uncleNode.ParentHash.String(),
+			BlockHash:  uncleNode.Hash().String(),
+			Reward:     uncleReward.String(),
+		}
+		if err := sdt.indexer.indexUncleCID(tx, uncle, headerID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// processArgs bundles arugments to processReceiptsAndTxs
+type processArgs struct {
+	headerID     int64
+	blockNumber  *big.Int
+	receipts     types.Receipts
+	txs          types.Transactions
+	rctNodes     []*ipld.EthReceipt
+	rctTrieNodes []*ipld.EthRctTrie
+	txNodes      []*ipld.EthTx
+	txTrieNodes  []*ipld.EthTxTrie
+}
+
+// processReceiptsAndTxs publishes and indexes receipt and transaction IPLDs in Postgres
+func (sdt *StateDiffTransformer) processReceiptsAndTxs(tx *sqlx.Tx, args processArgs) error {
+	// Process receipts and txs
+	signer := types.MakeSigner(sdt.chainConfig, args.blockNumber)
+	for i, receipt := range args.receipts {
+		// tx that corresponds with this receipt
+		trx := args.txs[i]
+		from, err := types.Sender(signer, trx)
+		if err != nil {
+			return err
+		}
+
+		// Publishing
+		// publish trie nodes, these aren't indexed directly
+		if err := shared.PublishIPLD(tx, args.txTrieNodes[i]); err != nil {
+			return err
+		}
+		if err := shared.PublishIPLD(tx, args.rctTrieNodes[i]); err != nil {
+			return err
+		}
+		// publish the txs and receipts
+		txNode, rctNode := args.txNodes[i], args.rctNodes[i]
+		if err := shared.PublishIPLD(tx, txNode); err != nil {
+			return err
+		}
+		if err := shared.PublishIPLD(tx, rctNode); err != nil {
+			return err
+		}
+
+		// Indexing
+		// extract topic and contract data from the receipt for indexing
+		topicSets := make([][]string, 4)
+		mappedContracts := make(map[string]bool) // use map to avoid duplicate addresses
+		for _, log := range receipt.Logs {
+			for i, topic := range log.Topics {
+				topicSets[i] = append(topicSets[i], topic.Hex())
+			}
+			mappedContracts[log.Address.String()] = true
+		}
+		// these are the contracts seen in the logs
+		logContracts := make([]string, 0, len(mappedContracts))
+		for addr := range mappedContracts {
+			logContracts = append(logContracts, addr)
+		}
+		// this is the contract address if this receipt is for a contract creation tx
+		contract := shared.HandleZeroAddr(receipt.ContractAddress)
+		var contractHash string
+		deployment := false
+		if contract != "" {
+			deployment = true
+			contractHash = crypto.Keccak256Hash(common.HexToAddress(contract).Bytes()).String()
+			// if tx is a contract deployment, publish the data (code)
+			// codec doesn't matter in this case sine we are not interested in the cid and the db key is multihash-derived
+			// TODO: THE DATA IS NOT DIRECTLY THE CONTRACT CODE; THERE IS A MISSING PROCESSING STEP HERE
+			// the contractHash => contract code is not currently correct
+			if _, err := shared.PublishRaw(tx, ipld.MEthStorageTrie, multihash.KECCAK_256, trx.Data()); err != nil {
+				return err
+			}
+		}
+		// index tx first so that the receipt can reference it by FK
+		txModel := TxModel{
+			Dst:        shared.HandleZeroAddrPointer(trx.To()),
+			Src:        shared.HandleZeroAddr(from),
+			TxHash:     trx.Hash().String(),
+			Index:      int64(i),
+			Data:       trx.Data(),
+			Deployment: deployment,
+			CID:        rctNode.Cid().String(),
+			MhKey:      shared.MultihashKeyFromCID(rctNode.Cid()),
+		}
+		txID, err := sdt.indexer.indexTransactionCID(tx, txModel, args.headerID)
+		if err != nil {
+			return err
+		}
+		// index the receipt
+		rctModel := ReceiptModel{
+			Topic0s:      topicSets[0],
+			Topic1s:      topicSets[1],
+			Topic2s:      topicSets[2],
+			Topic3s:      topicSets[3],
+			Contract:     contract,
+			ContractHash: contractHash,
+			LogContracts: logContracts,
+			CID:          txNode.Cid().String(),
+			MhKey:        shared.MultihashKeyFromCID(txNode.Cid()),
+		}
+		if err := sdt.indexer.indexReceiptCID(tx, rctModel, txID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// processStateAndStorage publishes and indexes state and storage nodes in Postgres
+func (sdt *StateDiffTransformer) processStateAndStorage(tx *sqlx.Tx, headerID int64, stateDiff *statediff.StateObject) error {
+	for _, stateNode := range stateDiff.Nodes {
+		// publish the state node
+		stateCIDStr, err := shared.PublishRaw(tx, ipld.MEthStateTrie, multihash.KECCAK_256, stateNode.NodeValue)
+		if err != nil {
+			return err
+		}
+		mhKey, _ := shared.MultihashKeyFromCIDString(stateCIDStr)
+		stateModel := StateNodeModel{
+			Path:     stateNode.Path,
+			StateKey: common.BytesToHash(stateNode.LeafKey).String(),
+			CID:      stateCIDStr,
+			MhKey:    mhKey,
+			NodeType: ResolveFromNodeType(stateNode.NodeType),
+		}
+		// index the state node, collect the stateID to reference by FK
+		stateID, err := sdt.indexer.indexStateCID(tx, stateModel, headerID)
+		if err != nil {
+			return err
+		}
+		// if we have a leaf, decode and index the account data
+		if stateNode.NodeType == statediff.Leaf {
+			var i []interface{}
+			if err := rlp.DecodeBytes(stateNode.NodeValue, &i); err != nil {
+				return err
+			}
+			if len(i) != 2 {
+				return fmt.Errorf("eth IPLDPublisher expected state leaf node rlp to decode into two elements")
+			}
+			var account state.Account
+			if err := rlp.DecodeBytes(i[1].([]byte), &account); err != nil {
+				return err
+			}
+			accountModel := StateAccountModel{
+				Balance:     account.Balance.String(),
+				Nonce:       account.Nonce,
+				CodeHash:    account.CodeHash,
+				StorageRoot: account.Root.String(),
+			}
+			if err := sdt.indexer.indexStateAccount(tx, accountModel, stateID); err != nil {
+				return err
+			}
+		}
+		// if there are any storage nodes associated with this node, publish and index them
+		for _, storageNode := range stateNode.StorageNodes {
+			storageCIDStr, err := shared.PublishRaw(tx, ipld.MEthStorageTrie, multihash.KECCAK_256, storageNode.NodeValue)
+			if err != nil {
+				return err
+			}
+			mhKey, _ := shared.MultihashKeyFromCIDString(storageCIDStr)
+			storageModel := StorageNodeModel{
+				Path:       storageNode.Path,
+				StorageKey: common.BytesToHash(storageNode.LeafKey).String(),
+				CID:        storageCIDStr,
+				MhKey:      mhKey,
+				NodeType:   ResolveFromNodeType(storageNode.NodeType),
+			}
+			if err := sdt.indexer.indexStorageCID(tx, storageModel, stateID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/eth/transformer_test.go
+++ b/pkg/eth/transformer_test.go
@@ -69,7 +69,7 @@ var _ = Describe("PublishAndIndexer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(header.CID).To(Equal(mocks.HeaderCID.String()))
 			Expect(header.TD).To(Equal(mocks.MockBlock.Difficulty().String()))
-			Expect(header.Reward).To(Equal("5000000000000000000"))
+			Expect(header.Reward).To(Equal("5000000000000011250"))
 			dc, err := cid.Decode(header.CID)
 			Expect(err).ToNot(HaveOccurred())
 			mhKey := dshelp.MultihashToDsKey(dc.Hash())

--- a/pkg/eth/transformer_test.go
+++ b/pkg/eth/transformer_test.go
@@ -1,0 +1,228 @@
+// VulcanizeDB
+// Copyright © 2019 Vulcanize
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth_test
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipfs/go-ipfs-ds-help"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vulcanize/ipld-eth-indexer/pkg/eth"
+	"github.com/vulcanize/ipld-eth-indexer/pkg/eth/mocks"
+	"github.com/vulcanize/ipld-eth-indexer/pkg/postgres"
+	"github.com/vulcanize/ipld-eth-indexer/pkg/shared"
+)
+
+var _ = Describe("PublishAndIndexer", func() {
+	var (
+		db          *postgres.DB
+		err         error
+		transformer *eth.StateDiffTransformer
+		ipfsPgGet   = `SELECT data FROM public.blocks
+					WHERE key = $1`
+	)
+	BeforeEach(func() {
+		db, err = shared.SetupDB()
+		Expect(err).ToNot(HaveOccurred())
+		transformer = eth.NewStateDiffTransformer(params.MainnetChainConfig, db)
+		var blockNumber int64
+		blockNumber, err = transformer.Transform(1, mocks.MockStateDiffPayload)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(blockNumber).To(Equal(mocks.BlockNumber.Int64()))
+	})
+	AfterEach(func() {
+		eth.TearDownDB(db)
+	})
+
+	Describe("Publish", func() {
+		It("Published and indexes header IPLDs in a single tx", func() {
+			pgStr := `SELECT cid, td, reward, id
+				FROM eth.header_cids
+				WHERE block_number = $1`
+			// check header was properly indexed
+			type res struct {
+				CID    string
+				TD     string
+				Reward string
+				ID     int
+			}
+			header := new(res)
+			err = db.QueryRowx(pgStr, 1).StructScan(header)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(header.CID).To(Equal(mocks.HeaderCID.String()))
+			Expect(header.TD).To(Equal(mocks.MockBlock.Difficulty().String()))
+			Expect(header.Reward).To(Equal("5000000000000000000"))
+			dc, err := cid.Decode(header.CID)
+			Expect(err).ToNot(HaveOccurred())
+			mhKey := dshelp.MultihashToDsKey(dc.Hash())
+			prefixedKey := blockstore.BlockPrefix.String() + mhKey.String()
+			var data []byte
+			err = db.Get(&data, ipfsPgGet, prefixedKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(Equal(mocks.MockHeaderRlp))
+		})
+
+		It("Publishes and indexes transaction IPLDs in a single tx", func() {
+			// check that txs were properly indexed
+			trxs := make([]string, 0)
+			pgStr := `SELECT transaction_cids.cid FROM eth.transaction_cids INNER JOIN eth.header_cids ON (transaction_cids.header_id = header_cids.id)
+				WHERE header_cids.block_number = $1`
+			err = db.Select(&trxs, pgStr, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(trxs)).To(Equal(3))
+			Expect(shared.ListContainsString(trxs, mocks.Trx1CID.String())).To(BeTrue())
+			Expect(shared.ListContainsString(trxs, mocks.Trx2CID.String())).To(BeTrue())
+			Expect(shared.ListContainsString(trxs, mocks.Trx3CID.String())).To(BeTrue())
+			// and published
+			for _, c := range trxs {
+				dc, err := cid.Decode(c)
+				Expect(err).ToNot(HaveOccurred())
+				mhKey := dshelp.MultihashToDsKey(dc.Hash())
+				prefixedKey := blockstore.BlockPrefix.String() + mhKey.String()
+				var data []byte
+				err = db.Get(&data, ipfsPgGet, prefixedKey)
+				Expect(err).ToNot(HaveOccurred())
+				switch c {
+				case mocks.Trx1CID.String():
+					Expect(data).To(Equal(mocks.MockTransactions.GetRlp(0)))
+				case mocks.Trx2CID.String():
+					Expect(data).To(Equal(mocks.MockTransactions.GetRlp(1)))
+				case mocks.Trx3CID.String():
+					Expect(data).To(Equal(mocks.MockTransactions.GetRlp(2)))
+				}
+			}
+		})
+
+		It("Publishes and indexes receipt IPLDs in a single tx", func() {
+			// check receipts were properly indexed
+			rcts := make([]string, 0)
+			pgStr := `SELECT receipt_cids.cid FROM eth.receipt_cids, eth.transaction_cids, eth.header_cids
+				WHERE receipt_cids.tx_id = transaction_cids.id 
+				AND transaction_cids.header_id = header_cids.id
+				AND header_cids.block_number = $1`
+			err = db.Select(&rcts, pgStr, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(rcts)).To(Equal(3))
+			Expect(shared.ListContainsString(rcts, mocks.Rct1CID.String())).To(BeTrue())
+			Expect(shared.ListContainsString(rcts, mocks.Rct2CID.String())).To(BeTrue())
+			Expect(shared.ListContainsString(rcts, mocks.Rct3CID.String())).To(BeTrue())
+			// and published
+			for _, c := range rcts {
+				dc, err := cid.Decode(c)
+				Expect(err).ToNot(HaveOccurred())
+				mhKey := dshelp.MultihashToDsKey(dc.Hash())
+				prefixedKey := blockstore.BlockPrefix.String() + mhKey.String()
+				var data []byte
+				err = db.Get(&data, ipfsPgGet, prefixedKey)
+				Expect(err).ToNot(HaveOccurred())
+				switch c {
+				case mocks.Rct1CID.String():
+					Expect(data).To(Equal(mocks.MockReceipts.GetRlp(0)))
+				case mocks.Rct2CID.String():
+					Expect(data).To(Equal(mocks.MockReceipts.GetRlp(1)))
+				case mocks.Rct3CID.String():
+					Expect(data).To(Equal(mocks.MockReceipts.GetRlp(2)))
+				}
+			}
+		})
+
+		It("Publishes and indexes state IPLDs in a single tx", func() {
+			// check that state nodes were properly indexed and published
+			stateNodes := make([]eth.StateNodeModel, 0)
+			pgStr := `SELECT state_cids.id, state_cids.cid, state_cids.state_leaf_key, state_cids.node_type, state_cids.state_path, state_cids.header_id
+				FROM eth.state_cids INNER JOIN eth.header_cids ON (state_cids.header_id = header_cids.id)
+				WHERE header_cids.block_number = $1`
+			err = db.Select(&stateNodes, pgStr, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(stateNodes)).To(Equal(2))
+			for _, stateNode := range stateNodes {
+				var data []byte
+				dc, err := cid.Decode(stateNode.CID)
+				Expect(err).ToNot(HaveOccurred())
+				mhKey := dshelp.MultihashToDsKey(dc.Hash())
+				prefixedKey := blockstore.BlockPrefix.String() + mhKey.String()
+				err = db.Get(&data, ipfsPgGet, prefixedKey)
+				Expect(err).ToNot(HaveOccurred())
+				pgStr = `SELECT * from eth.state_accounts WHERE state_id = $1`
+				var account eth.StateAccountModel
+				err = db.Get(&account, pgStr, stateNode.ID)
+				Expect(err).ToNot(HaveOccurred())
+				if stateNode.CID == mocks.State1CID.String() {
+					Expect(stateNode.NodeType).To(Equal(2))
+					Expect(stateNode.StateKey).To(Equal(common.BytesToHash(mocks.ContractLeafKey).Hex()))
+					Expect(stateNode.Path).To(Equal([]byte{'\x06'}))
+					Expect(data).To(Equal(mocks.ContractLeafNode))
+					Expect(account).To(Equal(eth.StateAccountModel{
+						ID:          account.ID,
+						StateID:     stateNode.ID,
+						Balance:     "0",
+						CodeHash:    mocks.ContractCodeHash.Bytes(),
+						StorageRoot: mocks.ContractRoot,
+						Nonce:       1,
+					}))
+				}
+				if stateNode.CID == mocks.State2CID.String() {
+					Expect(stateNode.NodeType).To(Equal(2))
+					Expect(stateNode.StateKey).To(Equal(common.BytesToHash(mocks.AccountLeafKey).Hex()))
+					Expect(stateNode.Path).To(Equal([]byte{'\x0c'}))
+					Expect(data).To(Equal(mocks.AccountLeafNode))
+					Expect(account).To(Equal(eth.StateAccountModel{
+						ID:          account.ID,
+						StateID:     stateNode.ID,
+						Balance:     "1000",
+						CodeHash:    mocks.AccountCodeHash.Bytes(),
+						StorageRoot: mocks.AccountRoot,
+						Nonce:       0,
+					}))
+				}
+			}
+			pgStr = `SELECT * from eth.state_accounts WHERE state_id = $1`
+		})
+
+		It("Publishes and indexes storage IPLDs in a single tx", func() {
+			// check that storage nodes were properly indexed
+			storageNodes := make([]eth.StorageNodeWithStateKeyModel, 0)
+			pgStr := `SELECT storage_cids.cid, state_cids.state_leaf_key, storage_cids.storage_leaf_key, storage_cids.node_type, storage_cids.storage_path 
+				FROM eth.storage_cids, eth.state_cids, eth.header_cids
+				WHERE storage_cids.state_id = state_cids.id 
+				AND state_cids.header_id = header_cids.id
+				AND header_cids.block_number = $1`
+			err = db.Select(&storageNodes, pgStr, 1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(storageNodes)).To(Equal(1))
+			Expect(storageNodes[0]).To(Equal(eth.StorageNodeWithStateKeyModel{
+				CID:        mocks.StorageCID.String(),
+				NodeType:   2,
+				StorageKey: common.BytesToHash(mocks.StorageLeafKey).Hex(),
+				StateKey:   common.BytesToHash(mocks.ContractLeafKey).Hex(),
+				Path:       []byte{},
+			}))
+			var data []byte
+			dc, err := cid.Decode(storageNodes[0].CID)
+			Expect(err).ToNot(HaveOccurred())
+			mhKey := dshelp.MultihashToDsKey(dc.Hash())
+			prefixedKey := blockstore.BlockPrefix.String() + mhKey.String()
+			err = db.Get(&data, ipfsPgGet, prefixedKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(Equal(mocks.StorageLeafNode))
+		})
+	})
+})

--- a/pkg/eth/types.go
+++ b/pkg/eth/types.go
@@ -22,8 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/statediff"
-
-	"github.com/vulcanize/ipld-eth-indexer/pkg/ipfs"
 )
 
 // ConvertedPayload is a custom type which packages raw ETH data for publishing to IPFS and filtering to subscribers
@@ -58,45 +56,4 @@ type CIDPayload struct {
 	StateNodeCIDs   []StateNodeModel
 	StateAccounts   map[string]StateAccountModel
 	StorageNodeCIDs map[string][]StorageNodeModel
-}
-
-// CIDWrapper is used to direct fetching of IPLDs from IPFS
-// Returned by CIDRetriever
-// Passed to IPLDFetcher
-type CIDWrapper struct {
-	BlockNumber  *big.Int
-	Header       HeaderModel
-	Uncles       []UncleModel
-	Transactions []TxModel
-	Receipts     []ReceiptModel
-	StateNodes   []StateNodeModel
-	StorageNodes []StorageNodeWithStateKeyModel
-}
-
-// IPLDs is used to package raw IPLD block data fetched from IPFS and returned by the server
-// Returned by IPLDFetcher and ResponseFilterer
-type IPLDs struct {
-	BlockNumber     *big.Int
-	TotalDifficulty *big.Int
-	Header          ipfs.BlockModel
-	Uncles          []ipfs.BlockModel
-	Transactions    []ipfs.BlockModel
-	Receipts        []ipfs.BlockModel
-	StateNodes      []StateNode
-	StorageNodes    []StorageNode
-}
-
-type StateNode struct {
-	Type         statediff.NodeType
-	StateLeafKey common.Hash
-	Path         []byte
-	IPLD         ipfs.BlockModel
-}
-
-type StorageNode struct {
-	Type           statediff.NodeType
-	StateLeafKey   common.Hash
-	StorageLeafKey common.Hash
-	Path           []byte
-	IPLD           ipfs.BlockModel
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -57,16 +57,17 @@ func NewDB(databaseConfig Config, node node.Info) (*DB, error) {
 func (db *DB) CreateNode(node *node.Info) error {
 	var nodeID int64
 	err := db.QueryRow(
-		`INSERT INTO nodes (genesis_block, network_id, node_id, client_name)
-                VALUES ($1, $2, $3, $4)
-                ON CONFLICT (genesis_block, network_id, node_id)
+		`INSERT INTO nodes (genesis_block, network_id, node_id, client_name, chain_id)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (genesis_block, network_id, node_id, chain_id)
                   DO UPDATE
                     SET genesis_block = $1,
                         network_id = $2,
                         node_id = $3,
-                        client_name = $4
+                        client_name = $4,
+						chain_id = $5
                 RETURNING id`,
-		node.GenesisBlock, node.NetworkID, node.ID, node.ClientName).Scan(&nodeID)
+		node.GenesisBlock, node.NetworkID, node.ID, node.ClientName, node.ChainID).Scan(&nodeID)
 	if err != nil {
 		return ErrUnableToSetNode(err)
 	}

--- a/pkg/sync/service.go
+++ b/pkg/sync/service.go
@@ -71,7 +71,7 @@ func NewIndexerService(settings *Config) (Indexer, error) {
 	if err != nil {
 		return nil, err
 	}
-	sn.Transformer = eth.NewStateDiffTransformer(sn.ChainConfig, settings.db)
+	sn.Transformer = eth.NewStateDiffTransformer(sn.ChainConfig, settings.DB)
 	sn.QuitChan = make(chan bool)
 	sn.Workers = settings.Workers
 	return sn, nil
@@ -98,7 +98,7 @@ func (sap *Service) Sync(wg *sync.WaitGroup) error {
 	// spin up publish worker goroutines
 	publishPayload := make(chan statediff.Payload, PayloadChanBufferSize)
 	for i := 1; i <= int(sap.Workers); i++ {
-		go sap.publish(wg, i, publishPayload)
+		go sap.transform(wg, i, publishPayload)
 		log.Debugf("ethereum sync worker %d successfully spun up", i)
 	}
 	wg.Add(1)
@@ -125,9 +125,9 @@ func (sap *Service) Sync(wg *sync.WaitGroup) error {
 	return nil
 }
 
-// publish is spun up by SyncAndConvert and receives converted chain data from that process
-// it publishes this data to IPFS and indexes their CIDs with useful metadata in Postgres
-func (sap *Service) publish(wg *sync.WaitGroup, id int, statediffChan <-chan statediff.Payload) {
+// transform is spun up by Sync and receives statediff payloads from it
+// it transforms this data into IPLD models and indexes their CIDs with useful metadata in Postgres
+func (sap *Service) transform(wg *sync.WaitGroup, id int, statediffChan <-chan statediff.Payload) {
 	wg.Add(1)
 	defer wg.Done()
 	for {
@@ -135,7 +135,7 @@ func (sap *Service) publish(wg *sync.WaitGroup, id int, statediffChan <-chan sta
 		case diff := <-statediffChan:
 			blockNumber, err := sap.Transformer.Transform(id, diff)
 			if err != nil {
-				log.Errorf("ethereum sync worker %d transformer error: %v", err)
+				log.Errorf("ethereum sync worker %d transformer error: %v", id, err)
 			}
 			log.Infof("ethereum sync worker %d transformed data at height %d", id, blockNumber)
 		case <-sap.QuitChan:

--- a/pkg/sync/service_test.go
+++ b/pkg/sync/service_test.go
@@ -35,8 +35,9 @@ var _ = Describe("Service", func() {
 			wg := new(sync.WaitGroup)
 			payloadChan := make(chan statediff.Payload, 1)
 			quitChan := make(chan bool, 1)
-			mockPublisher := &mocks.IPLDPublisher{
-				ReturnErr: nil,
+			mockTransformer := &mocks.Transformer{
+				ReturnErr:    nil,
+				ReturnHeight: mocks.BlockNumber.Int64(),
 			}
 			mockStreamer := &mocks.PayloadStreamer{
 				ReturnSub: &rpc.ClientSubscription{},
@@ -45,14 +46,9 @@ var _ = Describe("Service", func() {
 				},
 				ReturnErr: nil,
 			}
-			mockConverter := &mocks.PayloadConverter{
-				ReturnIPLDPayload: &mocks.MockConvertedPayload,
-				ReturnErr:         nil,
-			}
 			processor := &s.Service{
-				Publisher:   mockPublisher,
 				Streamer:    mockStreamer,
-				Converter:   mockConverter,
+				Transformer: mockTransformer,
 				PayloadChan: payloadChan,
 				QuitChan:    quitChan,
 				Workers:     1,
@@ -62,8 +58,7 @@ var _ = Describe("Service", func() {
 			time.Sleep(2 * time.Second)
 			close(quitChan)
 			wg.Wait()
-			Expect(mockConverter.PassedStatediffPayload).To(Equal(mocks.MockStateDiffPayload))
-			Expect(mockPublisher.PassedIPLDPayload).To(Equal(mocks.MockConvertedPayload))
+			Expect(mockTransformer.PassedStateDiff).To(Equal(mocks.MockStateDiffPayload))
 			Expect(mockStreamer.PassedPayloadChan).To(Equal(payloadChan))
 		})
 	})


### PR DESCRIPTION
Combined interface for performing all processing operations over single data iteration on single data model.

Breaking these processing steps up across distinct interfaces with more precisely defined roles was useful during design, development, testing, and readability- especially before the refactor away from `ipfs-blockchain-watcher` which provided generic service interfaces on top of the lower level chain-specific (fetcher, converter, publisher, indexer, etc)- but at this point the primary concern is performance optimization. Because of the size and structure of the statediff objects we are processing, there are significant in-memory data iteration costs.