### PR TITLE
indexes on cid table fields

### DIFF
--- a/db/migrations/00013_potgraphile_triggers.sql
+++ b/db/migrations/00013_potgraphile_triggers.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-create function eth.graphql_subscription() returns trigger as $$
+CREATE FUNCTION eth.graphql_subscription() returns TRIGGER as $$
 declare
     table_name text = TG_ARGV[0];
     attribute text = TG_ARGV[1];
@@ -23,48 +23,47 @@ $$ language plpgsql;
 -- +goose StatementEnd
 
 CREATE TRIGGER header_cids_ai
-    after insert on eth.header_cids
+    after INSERT ON eth.header_cids
     for each row
     execute procedure eth.graphql_subscription('header_cids', 'id');
 
 CREATE TRIGGER receipt_cids_ai
-    after insert on eth.receipt_cids
+    after INSERT ON eth.receipt_cids
     for each row
     execute procedure eth.graphql_subscription('receipt_cids', 'id');
 
 CREATE TRIGGER state_accounts_ai
-    after insert on eth.state_accounts
+    after INSERT ON eth.state_accounts
     for each row
     execute procedure eth.graphql_subscription('state_accounts', 'id');
 
 CREATE TRIGGER state_cids_ai
-    after insert on eth.state_cids
+    after INSERT ON eth.state_cids
     for each row
     execute procedure eth.graphql_subscription('state_cids', 'id');
 
 CREATE TRIGGER storage_cids_ai
-    after insert on eth.storage_cids
+    after INSERT ON eth.storage_cids
     for each row
     execute procedure eth.graphql_subscription('storage_cids', 'id');
 
 CREATE TRIGGER transaction_cids_ai
-    after insert on eth.transaction_cids
+    after INSERT ON eth.transaction_cids
     for each row
     execute procedure eth.graphql_subscription('transaction_cids', 'id');
 
 CREATE TRIGGER uncle_cids_ai
-    after insert on eth.uncle_cids
+    after INSERT ON eth.uncle_cids
     for each row
     execute procedure eth.graphql_subscription('uncle_cids', 'id');
 
 -- +goose Down
-drop trigger uncle_cids_ai on eth.uncle_cids;
-drop trigger transaction_cids_ai on eth.transaction_cids;
-drop trigger storage_cids_ai on eth.storage_cids;
-drop trigger state_cids_ai on eth.state_cids;
-drop trigger state_accounts_ai on eth.state_accounts;
-drop trigger receipt_cids_ai on eth.receipt_cids;
-drop trigger header_cids_ai on eth.header_cids;
+DROP TRIGGER uncle_cids_ai ON eth.uncle_cids;
+DROP TRIGGER transaction_cids_ai ON eth.transaction_cids;
+DROP TRIGGER storage_cids_ai ON eth.storage_cids;
+DROP TRIGGER state_cids_ai ON eth.state_cids;
+DROP TRIGGER state_accounts_ai ON eth.state_accounts;
+DROP TRIGGER receipt_cids_ai ON eth.receipt_cids;
+DROP TRIGGER header_cids_ai ON eth.header_cids;
 
-drop function eth.graphql_subscription();
-
+DROP FUNCTION eth.graphql_subscription();

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -1,0 +1,124 @@
+-- +goose Up
+-- header indexes
+CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number) WITH (pages_per_range = 32);
+
+CREATE INDEX block_hash_index ON eth.header_cids USING btree (block_hash);
+
+CREATE INDEX header_cid_index ON eth.header_cids USING btree (cid);
+
+CREATE INDEX header_mh_index ON eth.header_cids USING btree (mh_key);
+
+CREATE INDEX state_root_index ON eth.header_cids USING btree (state_root);
+
+CREATE INDEX timestamp_index ON eth.header_cids USING brin (timestamp) WITH (pages_per_range = 32);
+
+-- transaction indexes
+CREATE INDEX tx_header_id_index ON eth.transaction_cids USING brin (header_id) WITH (pages_per_range = 32);
+
+CREATE INDEX tx_hash_index ON eth.transaction_cids USING btree (tx_hash);
+
+CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid);
+
+CREATE INDEX tx_mh_index ON eth.transaction_cids USING btree (mh_key);
+
+CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
+
+CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
+
+CREATE INDEX tx_data_index ON eth.transaction_cids USING btree (tx_data);
+
+-- receipt indexes
+CREATE INDEX rct_tx_id_index ON eth.receipt_cids USING brin (tx_id) WITH (pages_per_range = 32);
+
+CREATE INDEX rct_cid_index ON eth.receipt_cids USING btree (cid);
+
+CREATE INDEX rct_mh_index ON eth.receipt_cids USING btree (mh_key);
+
+CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
+
+CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_hash);
+
+CREATE INDEX rct_topic0_index ON eth.receipt_cids USING gin (topic0s);
+
+CREATE INDEX rct_topic1_index ON eth.receipt_cids USING gin (topic1s);
+
+CREATE INDEX rct_topic2_index ON eth.receipt_cids USING gin (topic2s);
+
+CREATE INDEX rct_topic3_index ON eth.receipt_cids USING gin (topic3s);
+
+CREATE INDEX rct_log_contract_index ON eth.receipt_cids USING gin (log_contracts);
+
+-- state node indexes
+CREATE INDEX state_header_id_index ON eth.state_cids USING brin (header_id) WITH (pages_per_range = 32);
+
+CREATE INDEX state_leaf_key_index ON eth.state_cids USING btree (state_leaf_key);
+
+CREATE INDEX state_cid_index ON eth.state_cids USING btree (cid);
+
+CREATE INDEX state_mh_index ON eth.state_cids USING btree (mh_key);
+
+CREATE INDEX state_path_index ON eth.state_cids USING btree (state_path);
+
+-- storage node indexes
+CREATE INDEX storage_state_id_index ON eth.storage_cids USING brin (state_id) WITH (pages_per_range = 32);
+
+CREATE INDEX storage_leaf_key_index ON eth.storage_cids USING btree (storage_leaf_key);
+
+CREATE INDEX storage_cid_index ON eth.storage_cids USING btree (cid);
+
+CREATE INDEX storage_mh_index ON eth.storage_cids USING btree (mh_key);
+
+CREATE INDEX storage_path_index ON eth.storage_cids USING btree (storage_path);
+
+-- state accounts indexes
+CREATE INDEX account_state_id_index ON eth.state_accounts USING brin (state_id) WITH (pages_per_range = 32);
+
+CREATE INDEX storage_root_index ON eth.state_accounts USING btree (storage_root);
+
+-- +goose Down
+-- state account indexes
+DROP INDEX eth.storage_root_index;
+DROP INDEX eth.account_state_id_index;
+
+-- storage node indexes
+DROP INDEX eth.storage_path_index;
+DROP INDEX eth.storage_mh_index;
+DROP INDEX eth.storage_cid_index;
+DROP INDEX eth.storage_leaf_key_index;
+DROP INDEX eth.storage_state_id_index;
+
+-- state node indexes
+DROP INDEX eth.state_path_index;
+DROP INDEX eth.state_mh_index;
+DROP INDEX eth.state_cid_index;
+DROP INDEX eth.state_leaf_key_index;
+DROP INDEX eth.state_header_id_index;
+
+-- receipt indexes
+DROP INDEX eth.rct_log_contract_index;
+DROP INDEX eth.rct_topic3_index;
+DROP INDEX eth.rct_topic2_index;
+DROP INDEX eth.rct_topic1_index;
+DROP INDEX eth.rct_topic0_index;
+DROP INDEX eth.rct_contract_hash_index;
+DROP INDEX eth.rct_contract_index;
+DROP INDEX eth.rct_mh_index;
+DROP INDEX eth.rct_cid_index;
+DROP INDEX eth.rct_tx_id_index;
+
+-- transaction indexes
+DROP INDEX eth.tx_data_index;
+DROP INDEX eth.tx_src_index;
+DROP INDEX eth.tx_dst_index;
+DROP INDEX eth.tx_mh_index;
+DROP INDEX eth.tx_cid_index;
+DROP INDEX eth.tx_hash_index;
+DROP INDEX eth.tx_header_id_index;
+
+-- header indexes
+DROP INDEX eth.timestamp_index;
+DROP INDEX eth.state_root_index;
+DROP INDEX eth.header_mh_index;
+DROP INDEX eth.header_cid_index;
+DROP INDEX eth.block_hash_index;
+DROP INDEX eth.block_number_index;

--- a/db/migrations/00014_create_cid_indexes.sql
+++ b/db/migrations/00014_create_cid_indexes.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- header indexes
-CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number) WITH (pages_per_range = 32);
+CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number);
 
 CREATE INDEX block_hash_index ON eth.header_cids USING btree (block_hash);
 
@@ -10,10 +10,10 @@ CREATE INDEX header_mh_index ON eth.header_cids USING btree (mh_key);
 
 CREATE INDEX state_root_index ON eth.header_cids USING btree (state_root);
 
-CREATE INDEX timestamp_index ON eth.header_cids USING brin (timestamp) WITH (pages_per_range = 32);
+CREATE INDEX timestamp_index ON eth.header_cids USING brin (timestamp);
 
 -- transaction indexes
-CREATE INDEX tx_header_id_index ON eth.transaction_cids USING brin (header_id) WITH (pages_per_range = 32);
+CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
 
 CREATE INDEX tx_hash_index ON eth.transaction_cids USING btree (tx_hash);
 
@@ -28,7 +28,7 @@ CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
 CREATE INDEX tx_data_index ON eth.transaction_cids USING btree (tx_data);
 
 -- receipt indexes
-CREATE INDEX rct_tx_id_index ON eth.receipt_cids USING brin (tx_id) WITH (pages_per_range = 32);
+CREATE INDEX rct_tx_id_index ON eth.receipt_cids USING btree (tx_id);
 
 CREATE INDEX rct_cid_index ON eth.receipt_cids USING btree (cid);
 
@@ -49,7 +49,7 @@ CREATE INDEX rct_topic3_index ON eth.receipt_cids USING gin (topic3s);
 CREATE INDEX rct_log_contract_index ON eth.receipt_cids USING gin (log_contracts);
 
 -- state node indexes
-CREATE INDEX state_header_id_index ON eth.state_cids USING brin (header_id) WITH (pages_per_range = 32);
+CREATE INDEX state_header_id_index ON eth.state_cids USING btree (header_id);
 
 CREATE INDEX state_leaf_key_index ON eth.state_cids USING btree (state_leaf_key);
 
@@ -60,7 +60,7 @@ CREATE INDEX state_mh_index ON eth.state_cids USING btree (mh_key);
 CREATE INDEX state_path_index ON eth.state_cids USING btree (state_path);
 
 -- storage node indexes
-CREATE INDEX storage_state_id_index ON eth.storage_cids USING brin (state_id) WITH (pages_per_range = 32);
+CREATE INDEX storage_state_id_index ON eth.storage_cids USING btree (state_id);
 
 CREATE INDEX storage_leaf_key_index ON eth.storage_cids USING btree (storage_leaf_key);
 
@@ -71,7 +71,7 @@ CREATE INDEX storage_mh_index ON eth.storage_cids USING btree (mh_key);
 CREATE INDEX storage_path_index ON eth.storage_cids USING btree (storage_path);
 
 -- state accounts indexes
-CREATE INDEX account_state_id_index ON eth.state_accounts USING brin (state_id) WITH (pages_per_range = 32);
+CREATE INDEX account_state_id_index ON eth.state_accounts USING btree (state_id);
 
 CREATE INDEX storage_root_index ON eth.state_accounts USING btree (storage_root);
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -23,6 +23,34 @@ SET row_security = off;
 CREATE SCHEMA eth;
 
 
+--
+-- Name: graphql_subscription(); Type: FUNCTION; Schema: eth; Owner: -
+--
+
+CREATE FUNCTION eth.graphql_subscription() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $_$
+declare
+    table_name text = TG_ARGV[0];
+    attribute text = TG_ARGV[1];
+    id text;
+begin
+    execute 'select $1.' || quote_ident(attribute)
+        using new
+        into id;
+    perform pg_notify('postgraphile:' || table_name,
+                      json_build_object(
+                              '__node__', json_build_array(
+                              table_name,
+                              id
+                          )
+                          )::text
+        );
+    return new;
+end;
+$_$;
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -605,6 +633,300 @@ ALTER TABLE ONLY public.nodes
 
 ALTER TABLE ONLY public.nodes
     ADD CONSTRAINT nodes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: account_state_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX account_state_id_index ON eth.state_accounts USING brin (state_id) WITH (pages_per_range='32');
+
+
+--
+-- Name: block_hash_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX block_hash_index ON eth.header_cids USING btree (block_hash);
+
+
+--
+-- Name: block_number_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number) WITH (pages_per_range='32');
+
+
+--
+-- Name: header_cid_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX header_cid_index ON eth.header_cids USING btree (cid);
+
+
+--
+-- Name: header_mh_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX header_mh_index ON eth.header_cids USING btree (mh_key);
+
+
+--
+-- Name: rct_cid_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_cid_index ON eth.receipt_cids USING btree (cid);
+
+
+--
+-- Name: rct_contract_hash_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_contract_hash_index ON eth.receipt_cids USING btree (contract_hash);
+
+
+--
+-- Name: rct_contract_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_contract_index ON eth.receipt_cids USING btree (contract);
+
+
+--
+-- Name: rct_log_contract_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_log_contract_index ON eth.receipt_cids USING gin (log_contracts);
+
+
+--
+-- Name: rct_mh_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_mh_index ON eth.receipt_cids USING btree (mh_key);
+
+
+--
+-- Name: rct_topic0_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_topic0_index ON eth.receipt_cids USING gin (topic0s);
+
+
+--
+-- Name: rct_topic1_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_topic1_index ON eth.receipt_cids USING gin (topic1s);
+
+
+--
+-- Name: rct_topic2_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_topic2_index ON eth.receipt_cids USING gin (topic2s);
+
+
+--
+-- Name: rct_topic3_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_topic3_index ON eth.receipt_cids USING gin (topic3s);
+
+
+--
+-- Name: rct_tx_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX rct_tx_id_index ON eth.receipt_cids USING brin (tx_id) WITH (pages_per_range='32');
+
+
+--
+-- Name: state_cid_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_cid_index ON eth.state_cids USING btree (cid);
+
+
+--
+-- Name: state_header_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_header_id_index ON eth.state_cids USING brin (header_id) WITH (pages_per_range='32');
+
+
+--
+-- Name: state_leaf_key_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_leaf_key_index ON eth.state_cids USING btree (state_leaf_key);
+
+
+--
+-- Name: state_mh_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_mh_index ON eth.state_cids USING btree (mh_key);
+
+
+--
+-- Name: state_path_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_path_index ON eth.state_cids USING btree (state_path);
+
+
+--
+-- Name: state_root_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX state_root_index ON eth.header_cids USING btree (state_root);
+
+
+--
+-- Name: storage_cid_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_cid_index ON eth.storage_cids USING btree (cid);
+
+
+--
+-- Name: storage_leaf_key_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_leaf_key_index ON eth.storage_cids USING btree (storage_leaf_key);
+
+
+--
+-- Name: storage_mh_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_mh_index ON eth.storage_cids USING btree (mh_key);
+
+
+--
+-- Name: storage_path_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_path_index ON eth.storage_cids USING btree (storage_path);
+
+
+--
+-- Name: storage_root_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_root_index ON eth.state_accounts USING btree (storage_root);
+
+
+--
+-- Name: storage_state_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX storage_state_id_index ON eth.storage_cids USING brin (state_id) WITH (pages_per_range='32');
+
+
+--
+-- Name: timestamp_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX timestamp_index ON eth.header_cids USING brin ("timestamp") WITH (pages_per_range='32');
+
+
+--
+-- Name: tx_cid_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_cid_index ON eth.transaction_cids USING btree (cid);
+
+
+--
+-- Name: tx_data_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_data_index ON eth.transaction_cids USING btree (tx_data);
+
+
+--
+-- Name: tx_dst_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_dst_index ON eth.transaction_cids USING btree (dst);
+
+
+--
+-- Name: tx_hash_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_hash_index ON eth.transaction_cids USING btree (tx_hash);
+
+
+--
+-- Name: tx_header_id_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_header_id_index ON eth.transaction_cids USING brin (header_id) WITH (pages_per_range='32');
+
+
+--
+-- Name: tx_mh_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_mh_index ON eth.transaction_cids USING btree (mh_key);
+
+
+--
+-- Name: tx_src_index; Type: INDEX; Schema: eth; Owner: -
+--
+
+CREATE INDEX tx_src_index ON eth.transaction_cids USING btree (src);
+
+
+--
+-- Name: header_cids header_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER header_cids_ai AFTER INSERT ON eth.header_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('header_cids', 'id');
+
+
+--
+-- Name: receipt_cids receipt_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER receipt_cids_ai AFTER INSERT ON eth.receipt_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('receipt_cids', 'id');
+
+
+--
+-- Name: state_accounts state_accounts_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER state_accounts_ai AFTER INSERT ON eth.state_accounts FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('state_accounts', 'id');
+
+
+--
+-- Name: state_cids state_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER state_cids_ai AFTER INSERT ON eth.state_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('state_cids', 'id');
+
+
+--
+-- Name: storage_cids storage_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER storage_cids_ai AFTER INSERT ON eth.storage_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('storage_cids', 'id');
+
+
+--
+-- Name: transaction_cids transaction_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER transaction_cids_ai AFTER INSERT ON eth.transaction_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('transaction_cids', 'id');
+
+
+--
+-- Name: uncle_cids uncle_cids_ai; Type: TRIGGER; Schema: eth; Owner: -
+--
+
+CREATE TRIGGER uncle_cids_ai AFTER INSERT ON eth.uncle_cids FOR EACH ROW EXECUTE FUNCTION eth.graphql_subscription('uncle_cids', 'id');
 
 
 --

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -639,7 +639,7 @@ ALTER TABLE ONLY public.nodes
 -- Name: account_state_id_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX account_state_id_index ON eth.state_accounts USING brin (state_id) WITH (pages_per_range='32');
+CREATE INDEX account_state_id_index ON eth.state_accounts USING btree (state_id);
 
 
 --
@@ -653,7 +653,7 @@ CREATE INDEX block_hash_index ON eth.header_cids USING btree (block_hash);
 -- Name: block_number_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number) WITH (pages_per_range='32');
+CREATE INDEX block_number_index ON eth.header_cids USING brin (block_number);
 
 
 --
@@ -737,7 +737,7 @@ CREATE INDEX rct_topic3_index ON eth.receipt_cids USING gin (topic3s);
 -- Name: rct_tx_id_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX rct_tx_id_index ON eth.receipt_cids USING brin (tx_id) WITH (pages_per_range='32');
+CREATE INDEX rct_tx_id_index ON eth.receipt_cids USING btree (tx_id);
 
 
 --
@@ -751,7 +751,7 @@ CREATE INDEX state_cid_index ON eth.state_cids USING btree (cid);
 -- Name: state_header_id_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX state_header_id_index ON eth.state_cids USING brin (header_id) WITH (pages_per_range='32');
+CREATE INDEX state_header_id_index ON eth.state_cids USING btree (header_id);
 
 
 --
@@ -821,14 +821,14 @@ CREATE INDEX storage_root_index ON eth.state_accounts USING btree (storage_root)
 -- Name: storage_state_id_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX storage_state_id_index ON eth.storage_cids USING brin (state_id) WITH (pages_per_range='32');
+CREATE INDEX storage_state_id_index ON eth.storage_cids USING btree (state_id);
 
 
 --
 -- Name: timestamp_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX timestamp_index ON eth.header_cids USING brin ("timestamp") WITH (pages_per_range='32');
+CREATE INDEX timestamp_index ON eth.header_cids USING brin ("timestamp");
 
 
 --
@@ -863,7 +863,7 @@ CREATE INDEX tx_hash_index ON eth.transaction_cids USING btree (tx_hash);
 -- Name: tx_header_id_index; Type: INDEX; Schema: eth; Owner: -
 --
 
-CREATE INDEX tx_header_id_index ON eth.transaction_cids USING brin (header_id) WITH (pages_per_range='32');
+CREATE INDEX tx_header_id_index ON eth.transaction_cids USING btree (header_id);
 
 
 --


### PR DESCRIPTION
Using BRIN indexes on block_number, timestamp, and id FK references (sequential, numeric rows)

Using GIN indexes on topic0s, topic1s, topic2s, topic3s, log_contracts (array rows)

Using BTREE indexes on everything else

Difficult to estimate without benchmarking what the optimal `pages_per_range` value for the BRIN indexes is, but assuming most of the queries against those receipt fields will be returning a single or few records at a time I have it set to 32 for now. The smaller the `pages_per_range` value, the more space the index takes up, but the better granularity it provides and it will perform better for any `SELECT` queries that return a number of records less than or equal to the `pages_per_range` value.