### PR TITLE
processing time trace in transformer

### DIFF
--- a/pkg/eth/mocks/transformer.go
+++ b/pkg/eth/mocks/transformer.go
@@ -24,12 +24,12 @@ import (
 type Transformer struct {
 	PassedWorkerID  int
 	PassedStateDiff statediff.Payload
-	ReturnHeight    int64
+	ReturnHeight    uint64
 	ReturnErr       error
 }
 
 // Transform mock method
-func (t *Transformer) Transform(workerID int, payload statediff.Payload) (int64, error) {
+func (t *Transformer) Transform(workerID int, payload statediff.Payload) (uint64, error) {
 	t.PassedWorkerID = workerID
 	t.PassedStateDiff = payload
 	return t.ReturnHeight, t.ReturnErr
@@ -39,13 +39,13 @@ func (t *Transformer) Transform(workerID int, payload statediff.Payload) (int64,
 type IterativeTransformer struct {
 	PassedWorkerIDs  []int
 	PassedStateDiffs []statediff.Payload
-	ReturnHeights    []int64
+	ReturnHeights    []uint64
 	ReturnErr        error
 	iteration        int
 }
 
 // Transform mock method
-func (t *IterativeTransformer) Transform(workerID int, payload statediff.Payload) (int64, error) {
+func (t *IterativeTransformer) Transform(workerID int, payload statediff.Payload) (uint64, error) {
 	t.PassedWorkerIDs = append(t.PassedWorkerIDs, workerID)
 	t.PassedStateDiffs = append(t.PassedStateDiffs, payload)
 	height := t.ReturnHeights[t.iteration]

--- a/pkg/eth/publisher.go
+++ b/pkg/eth/publisher.go
@@ -116,7 +116,7 @@ func (pub *IPLDPublisher) Publish(payload ConvertedPayload) error {
 		if err := shared.PublishIPLD(tx, uncleNode); err != nil {
 			return err
 		}
-		uncleReward := CalcUncleMinerReward(payload.Block.Number().Int64(), uncleNode.Number.Int64())
+		uncleReward := CalcUncleMinerReward(payload.Block.Number().Uint64(), uncleNode.Number.Uint64())
 		uncle := UncleModel{
 			CID:        uncleNode.Cid().String(),
 			MhKey:      shared.MultihashKeyFromCID(uncleNode.Cid()),

--- a/pkg/eth/reward.go
+++ b/pkg/eth/reward.go
@@ -23,24 +23,24 @@ import (
 )
 
 func CalcEthBlockReward(header *types.Header, uncles []*types.Header, txs types.Transactions, receipts types.Receipts) *big.Int {
-	staticBlockReward := staticRewardByBlockNumber(header.Number.Int64())
+	staticBlockReward := staticRewardByBlockNumber(header.Number.Uint64())
 	transactionFees := calcEthTransactionFees(txs, receipts)
 	uncleInclusionRewards := calcEthUncleInclusionRewards(header, uncles)
 	tmp := transactionFees.Add(transactionFees, uncleInclusionRewards)
 	return tmp.Add(tmp, staticBlockReward)
 }
 
-func CalcUncleMinerReward(blockNumber, uncleBlockNumber int64) *big.Int {
+func CalcUncleMinerReward(blockNumber, uncleBlockNumber uint64) *big.Int {
 	staticBlockReward := staticRewardByBlockNumber(blockNumber)
 	rewardDiv8 := staticBlockReward.Div(staticBlockReward, big.NewInt(8))
-	mainBlock := big.NewInt(blockNumber)
-	uncleBlock := big.NewInt(uncleBlockNumber)
+	mainBlock := new(big.Int).SetUint64(blockNumber)
+	uncleBlock := new(big.Int).SetUint64(uncleBlockNumber)
 	uncleBlockPlus8 := uncleBlock.Add(uncleBlock, big.NewInt(8))
 	uncleBlockPlus8MinusMainBlock := uncleBlockPlus8.Sub(uncleBlockPlus8, mainBlock)
 	return rewardDiv8.Mul(rewardDiv8, uncleBlockPlus8MinusMainBlock)
 }
 
-func staticRewardByBlockNumber(blockNumber int64) *big.Int {
+func staticRewardByBlockNumber(blockNumber uint64) *big.Int {
 	staticBlockReward := new(big.Int)
 	//https://blog.ethereum.org/2017/10/12/byzantium-hf-announcement/
 	if blockNumber >= 7280000 {
@@ -68,7 +68,7 @@ func calcEthTransactionFees(txs types.Transactions, receipts types.Receipts) *bi
 func calcEthUncleInclusionRewards(header *types.Header, uncles []*types.Header) *big.Int {
 	uncleInclusionRewards := new(big.Int)
 	for range uncles {
-		staticBlockReward := staticRewardByBlockNumber(header.Number.Int64())
+		staticBlockReward := staticRewardByBlockNumber(header.Number.Uint64())
 		staticBlockReward.Div(staticBlockReward, big.NewInt(32))
 		uncleInclusionRewards.Add(uncleInclusionRewards, staticBlockReward)
 	}

--- a/pkg/eth/transformer_test.go
+++ b/pkg/eth/transformer_test.go
@@ -43,10 +43,10 @@ var _ = Describe("PublishAndIndexer", func() {
 		db, err = shared.SetupDB()
 		Expect(err).ToNot(HaveOccurred())
 		transformer = eth.NewStateDiffTransformer(params.MainnetChainConfig, db)
-		var blockNumber int64
+		var blockNumber uint64
 		blockNumber, err = transformer.Transform(1, mocks.MockStateDiffPayload)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(blockNumber).To(Equal(mocks.BlockNumber.Int64()))
+		Expect(blockNumber).To(Equal(mocks.BlockNumber.Uint64()))
 	})
 	AfterEach(func() {
 		eth.TearDownDB(db)

--- a/pkg/historical/service_test.go
+++ b/pkg/historical/service_test.go
@@ -35,7 +35,7 @@ var _ = Describe("BackFiller", func() {
 		It("Periodically checks for and fills in gaps in the watcher's data", func() {
 			mockTransformer := &mocks.IterativeTransformer{
 				ReturnErr:     nil,
-				ReturnHeights: []int64{100, 101},
+				ReturnHeights: []uint64{100, 101},
 			}
 			mockRetriever := &mocks.Retriever{
 				FirstBlockNumberToReturn: 0,
@@ -76,7 +76,7 @@ var _ = Describe("BackFiller", func() {
 		It("Works for single block `ranges`", func() {
 			mockTransformer := &mocks.IterativeTransformer{
 				ReturnErr:     nil,
-				ReturnHeights: []int64{100},
+				ReturnHeights: []uint64{100},
 			}
 			mockRetriever := &mocks.Retriever{
 				FirstBlockNumberToReturn: 0,
@@ -115,7 +115,7 @@ var _ = Describe("BackFiller", func() {
 		It("Finds beginning gap", func() {
 			mockTransformer := &mocks.IterativeTransformer{
 				ReturnErr:     nil,
-				ReturnHeights: []int64{0, 1, 2},
+				ReturnHeights: []uint64{0, 1, 2},
 			}
 			mockRetriever := &mocks.Retriever{
 				FirstBlockNumberToReturn: 3,

--- a/pkg/sync/service_test.go
+++ b/pkg/sync/service_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Service", func() {
 			quitChan := make(chan bool, 1)
 			mockTransformer := &mocks.Transformer{
 				ReturnErr:    nil,
-				ReturnHeight: mocks.BlockNumber.Int64(),
+				ReturnHeight: mocks.BlockNumber.Uint64(),
 			}
 			mockStreamer := &mocks.PayloadStreamer{
 				ReturnSub: &rpc.ClientSubscription{},


### PR DESCRIPTION
e.g.

```
INFO[2020-09-27T20:16:02-05:00] worker 2 transformer stats for payload at 237812 with hash 0x95ecd4e57790c9ebf22d1447af5d09b44becc00b8988e4e0e704ceaadfdc9383:  
payload decoding time: 547.907µs
time spent waiting for free postgres tx: 1.072015ms:
header processing time: 19.883064ms
uncle processing time: 284ns
tx and receipt processing time: 21.839089ms
state and storage processing time: 74.556038ms
postgres transaction commit duration: 10.825089ms
 TOTAL PROCESSING TIME: 128.809804ms
```
