### PR TITLE
add poststatus and state to receipt_cids

### DIFF
--- a/db/migrations/00018_eth_header_cid_by_blocknumber.sql
+++ b/db/migrations/00018_eth_header_cid_by_blocknumber.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE FUNCTION "ethHeaderCidByBlockNumber"(n bigint) returns SETOF eth.header_cids
+    stable
+    language sql
+as
+$$
+SELECT * FROM eth.header_cids WHERE block_number=$1 ORDER BY id
+$$;
+
+-- +goose Down
+DROP FUNCTION "ethHeaderCidByBlockNumber"(bigint);

--- a/db/migrations/00019_add_poststate_and_status_to_receipt_cids.sql
+++ b/db/migrations/00019_add_poststate_and_status_to_receipt_cids.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE eth.receipt_cids
+ADD COLUMN post_state VARCHAR(66);
+
+ALTER TABLE eth.receipt_cids
+ADD COLUMN post_status INTEGER;
+
+-- +goose Down
+ALTER TABLE eth.receipt_cids
+DROP COLUMN post_status;
+
+ALTER TABLE eth.receipt_cids
+DROP COLUMN post_state;

--- a/pkg/eth/indexer.go
+++ b/pkg/eth/indexer.go
@@ -142,9 +142,9 @@ func (in *CIDIndexer) indexTransactionCID(tx *sqlx.Tx, transaction TxModel, head
 }
 
 func (in *CIDIndexer) indexReceiptCID(tx *sqlx.Tx, rct ReceiptModel, txID int64) error {
-	_, err := tx.Exec(`INSERT INTO eth.receipt_cids (tx_id, cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-							  ON CONFLICT (tx_id) DO UPDATE SET (cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key) = ($2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-		txID, rct.CID, rct.Contract, rct.ContractHash, rct.Topic0s, rct.Topic1s, rct.Topic2s, rct.Topic3s, rct.LogContracts, rct.MhKey)
+	_, err := tx.Exec(`INSERT INTO eth.receipt_cids (tx_id, cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key, post_state, post_status) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+							  ON CONFLICT (tx_id) DO UPDATE SET (cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key, post_state, post_status) = ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		txID, rct.CID, rct.Contract, rct.ContractHash, rct.Topic0s, rct.Topic1s, rct.Topic2s, rct.Topic3s, rct.LogContracts, rct.MhKey, rct.PostState, rct.PostStatus)
 	if err == nil {
 		prom.ReceiptInc()
 	}

--- a/pkg/eth/mocks/test_data.go
+++ b/pkg/eth/mocks/test_data.go
@@ -158,8 +158,9 @@ var (
 	}
 	MockRctMeta = []eth.ReceiptModel{
 		{
-			CID:   "",
-			MhKey: "",
+			CID:        "",
+			MhKey:      "",
+			PostStatus: 1,
 			Topic0s: []string{
 				mockTopic11.String(),
 			},
@@ -173,8 +174,9 @@ var (
 			},
 		},
 		{
-			CID:   "",
-			MhKey: "",
+			CID:       "",
+			MhKey:     "",
+			PostState: common.Bytes2Hex(common.HexToHash("0x1").Bytes()),
 			Topic0s: []string{
 				mockTopic21.String(),
 			},
@@ -190,6 +192,7 @@ var (
 		{
 			CID:          "",
 			MhKey:        "",
+			PostState:    common.Bytes2Hex(common.HexToHash("0x2").Bytes()),
 			Contract:     ContractAddress.String(),
 			ContractHash: ContractHash,
 			LogContracts: []string{},
@@ -197,8 +200,9 @@ var (
 	}
 	MockRctMetaPostPublish = []eth.ReceiptModel{
 		{
-			CID:   Rct1CID.String(),
-			MhKey: Rct1MhKey,
+			CID:        Rct1CID.String(),
+			MhKey:      Rct1MhKey,
+			PostStatus: 1,
 			Topic0s: []string{
 				mockTopic11.String(),
 			},
@@ -212,8 +216,9 @@ var (
 			},
 		},
 		{
-			CID:   Rct2CID.String(),
-			MhKey: Rct2MhKey,
+			CID:       Rct2CID.String(),
+			MhKey:     Rct2MhKey,
+			PostState: common.Bytes2Hex(common.HexToHash("0x1").Bytes()),
 			Topic0s: []string{
 				mockTopic21.String(),
 			},
@@ -229,6 +234,7 @@ var (
 		{
 			CID:          Rct3CID.String(),
 			MhKey:        Rct3MhKey,
+			PostState:    common.Bytes2Hex(common.HexToHash("0x2").Bytes()),
 			Contract:     ContractAddress.String(),
 			ContractHash: ContractHash,
 			LogContracts: []string{},
@@ -467,7 +473,7 @@ func createTransactionsAndReceipts() (types.Transactions, types.Receipts, common
 		log.Fatal(err)
 	}
 	// make receipts
-	mockReceipt1 := types.NewReceipt(common.HexToHash("0x0").Bytes(), false, 50)
+	mockReceipt1 := types.NewReceipt(nil, false, 50)
 	mockReceipt1.Logs = []*types.Log{MockLog1}
 	mockReceipt1.TxHash = signedTrx1.Hash()
 	mockReceipt2 := types.NewReceipt(common.HexToHash("0x1").Bytes(), false, 100)

--- a/pkg/eth/models.go
+++ b/pkg/eth/models.go
@@ -68,6 +68,8 @@ type ReceiptModel struct {
 	TxID         int64          `db:"tx_id"`
 	CID          string         `db:"cid"`
 	MhKey        string         `db:"mh_key"`
+	PostStatus   uint64         `db:"post_status"`
+	PostState    string         `db:"post_state"`
 	Contract     string         `db:"contract"`
 	ContractHash string         `db:"contract_hash"`
 	LogContracts pq.StringArray `db:"log_contracts"`

--- a/pkg/eth/publisher.go
+++ b/pkg/eth/publisher.go
@@ -148,6 +148,11 @@ func (pub *IPLDPublisher) Publish(payload ConvertedPayload) error {
 		rctModel := payload.ReceiptMetaData[i]
 		rctModel.CID = rctNode.Cid().String()
 		rctModel.MhKey = shared.MultihashKeyFromCID(rctNode.Cid())
+		if len(payload.Receipts[i].PostState) == 0 {
+			rctModel.PostStatus = payload.Receipts[i].Status
+		} else {
+			rctModel.PostState = common.Bytes2Hex(payload.Receipts[i].PostState)
+		}
 		if err := pub.indexer.indexReceiptCID(tx, rctModel, txID); err != nil {
 			return err
 		}

--- a/pkg/eth/transformer.go
+++ b/pkg/eth/transformer.go
@@ -312,6 +312,11 @@ func (sdt *StateDiffTransformer) processReceiptsAndTxs(tx *sqlx.Tx, args process
 			CID:          rctNode.Cid().String(),
 			MhKey:        shared.MultihashKeyFromCID(rctNode.Cid()),
 		}
+		if len(receipt.PostState) == 0 {
+			rctModel.PostStatus = receipt.Status
+		} else {
+			rctModel.PostState = common.Bytes2Hex(receipt.PostState)
+		}
 		if err := sdt.indexer.indexReceiptCID(tx, rctModel, txID); err != nil {
 			return err
 		}

--- a/pkg/eth/transformer_test.go
+++ b/pkg/eth/transformer_test.go
@@ -136,10 +136,25 @@ var _ = Describe("PublishAndIndexer", func() {
 				switch c {
 				case mocks.Rct1CID.String():
 					Expect(data).To(Equal(mocks.MockReceipts.GetRlp(0)))
+					var postStatus uint64
+					pgStr = `SELECT post_status FROM eth.receipt_cids WHERE cid = $1`
+					err = db.Get(&postStatus, pgStr, c)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(postStatus).To(Equal(mocks.MockRctMeta[0].PostStatus))
 				case mocks.Rct2CID.String():
 					Expect(data).To(Equal(mocks.MockReceipts.GetRlp(1)))
+					var postState string
+					pgStr = `SELECT post_state FROM eth.receipt_cids WHERE cid = $1`
+					err = db.Get(&postState, pgStr, c)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(postState).To(Equal(mocks.MockRctMeta[1].PostState))
 				case mocks.Rct3CID.String():
 					Expect(data).To(Equal(mocks.MockReceipts.GetRlp(2)))
+					var postState string
+					pgStr = `SELECT post_state FROM eth.receipt_cids WHERE cid = $1`
+					err = db.Get(&postState, pgStr, c)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(postState).To(Equal(mocks.MockRctMeta[2].PostState))
 				}
 			}
 		})


### PR DESCRIPTION
* add poststatus and state to receipt_cids
* update unit test

Satisfies #73 

Note: after EIP 98 only status is stored in receipt, before EIP 98 the intermediate state root is packed into those bytes ethereum/EIPs#98