### PR TITLE
added option to skip writing to public.nodes table

### DIFF
--- a/pkg/historical/config.go
+++ b/pkg/historical/config.go
@@ -94,7 +94,7 @@ func NewConfig() (*Config, error) {
 
 	c.DBConfig.Init()
 	overrideDBConnConfig(&c.DBConfig)
-	db := utils.LoadPostgres(c.DBConfig, c.NodeInfo)
+	db := utils.LoadPostgres(c.DBConfig, c.NodeInfo, true)
 	c.DB = &db
 	return c, nil
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -31,7 +31,7 @@ type DB struct {
 	NodeID int64
 }
 
-func NewDB(databaseConfig Config, node node.Info) (*DB, error) {
+func NewDB(databaseConfig Config, node node.Info, createNode bool) (*DB, error) {
 	connectString := DbConnectionString(databaseConfig)
 	db, connectErr := sqlx.Connect("postgres", connectString)
 	if connectErr != nil {
@@ -49,10 +49,14 @@ func NewDB(databaseConfig Config, node node.Info) (*DB, error) {
 		db.SetConnMaxLifetime(lifetime)
 	}
 	pg := DB{DB: db, Node: node}
-	nodeErr := pg.CreateNode(&node)
-	if nodeErr != nil {
-		return &DB{}, ErrUnableToSetNode(nodeErr)
+
+	if createNode {
+		nodeErr := pg.CreateNode(&node)
+		if nodeErr != nil {
+			return &DB{}, ErrUnableToSetNode(nodeErr)
+		}
 	}
+
 	return &pg, nil
 }
 

--- a/pkg/postgres/postgres_test.go
+++ b/pkg/postgres/postgres_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Postgres DB", func() {
 		invalidDatabase := postgres.Config{}
 		node := node.Info{GenesisBlock: "GENESIS", NetworkID: "1", ID: "x123", ClientName: "geth"}
 
-		_, err := postgres.NewDB(invalidDatabase, node)
+		_, err := postgres.NewDB(invalidDatabase, node, true)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(postgres.DbConnectionFailedMsg))

--- a/pkg/resync/config.go
+++ b/pkg/resync/config.go
@@ -112,7 +112,7 @@ func NewConfig() (*Config, error) {
 
 	c.DBConfig.Init()
 	overrideDBConnConfig(&c.DBConfig)
-	db := utils.LoadPostgres(c.DBConfig, c.NodeInfo)
+	db := utils.LoadPostgres(c.DBConfig, c.NodeInfo, true)
 	c.DB = &db
 	return c, nil
 }

--- a/pkg/shared/test_helpers.go
+++ b/pkg/shared/test_helpers.go
@@ -28,11 +28,11 @@ import (
 
 // SetupDB is use to setup a db for watcher tests
 func SetupDB() (*postgres.DB, error) {
-	return postgres.NewDB(getTestConfig(), node.Info{})
+	return postgres.NewDB(getTestConfig(), node.Info{}, true)
 }
 
 func SetupDBWithNode(node node.Info) (*postgres.DB, error) {
-	return postgres.NewDB(getTestConfig(), node)
+	return postgres.NewDB(getTestConfig(), node, true)
 }
 
 func getTestConfig() postgres.Config {

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -67,7 +67,7 @@ func NewConfig() (*Config, error) {
 
 	c.DBConfig.Init()
 	overrideDBConnConfig(&c.DBConfig)
-	syncDB := utils.LoadPostgres(c.DBConfig, c.NodeInfo)
+	syncDB := utils.LoadPostgres(c.DBConfig, c.NodeInfo, true)
 	c.DB = &syncDB
 	return c, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -25,8 +25,8 @@ import (
 	"github.com/vulcanize/ipld-eth-indexer/pkg/postgres"
 )
 
-func LoadPostgres(database postgres.Config, node node.Info) postgres.DB {
-	db, err := postgres.NewDB(database, node)
+func LoadPostgres(database postgres.Config, node node.Info, createNode bool) postgres.DB {
+	db, err := postgres.NewDB(database, node, createNode)
 	if err != nil {
 		logrus.Fatal("Error loading postgres: ", err)
 	}


### PR DESCRIPTION
Usually, indexer instance adds new entry to public.nodes tables and it used in eth.header_cid relationship to understand from which node header came from. But ipld-eth-server and tracing-api also uses ipld-eth-indexer as library but they don't need to insert this entity to the database